### PR TITLE
Implement youtube api

### DIFF
--- a/js/authTypes/OAuth2PKCEAuth.js
+++ b/js/authTypes/OAuth2PKCEAuth.js
@@ -37,8 +37,10 @@ export class OAuth2PKCEAuth extends Authentication{
 				request["code_challenge"] = await EncodeVerifier(verifier), // used for server-verificaiton
 				request["code_challenge_method"] = "S256"
 			}
-			if(manuallyTriggered)
+			if(manuallyTriggered){
 				request["force_verify"] = true
+				request["prompt"] = "consent"
+			}
 			const redirectUri = await Browser.LaunchWebAuthFlow(EncodeDataURL(this._authURI, request), manuallyTriggered)
 			//console.log(redirectUri)
 			let query = DecodeUriQuery(redirectUri)
@@ -58,6 +60,7 @@ export class OAuth2PKCEAuth extends Authentication{
 	}
 
 	async Refresh(auth){
+		if(!this._tokenURI) return this.Authenticate(true)
 		return this._RefreshAccessToken({
 			"client_id":this.ClientID,
 			"grant_type":"refresh_token",

--- a/js/authTypes/OAuth2PKCEAuth.js
+++ b/js/authTypes/OAuth2PKCEAuth.js
@@ -37,10 +37,6 @@ export class OAuth2PKCEAuth extends Authentication{
 				request["code_challenge"] = await EncodeVerifier(verifier), // used for server-verificaiton
 				request["code_challenge_method"] = "S256"
 			}
-			if(manuallyTriggered){
-				request["force_verify"] = true
-				request["prompt"] = "consent"
-			}
 			const redirectUri = await Browser.LaunchWebAuthFlow(EncodeDataURL(this._authURI, request), manuallyTriggered)
 			//console.log(redirectUri)
 			let query = DecodeUriQuery(redirectUri)

--- a/js/providers/youtube.js
+++ b/js/providers/youtube.js
@@ -9,15 +9,17 @@ export class Youtube extends Provider(OAuth2PKCEAuth){
 	}
 
 	async GetUIDAndName(auth){
+		console.log(auth)
 		var userData = (await WebRequest.GET("https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true&fields=items(id,snippet/title)", this.Payload(auth)))["items"][0]
 		return [userData["id"], userData["snippet"]["title"]]
 	}
 
 	async FetchStreams(auth, UID){
+		// TODO: this only gets 50 results, needs paging to get moar
 		const snippets = (await WebRequest.GET("https://www.googleapis.com/youtube/v3/subscriptions?part=snippet&mine=true&order=unread&maxResults=50&fields=items(snippet(title,resourceId/channelId,thumbnails/default/url))", this.Payload(auth)))["items"].map(s=>s["snippet"])
 		const filtered = await AsyncFilter(snippets, async s => {
 			const url = s["_url"] = `https://www.youtube.com/channel/${s["resourceId"]["channelId"]}/live`
-			const metadata = Object.fromEntries((await fetch(url).then(r=>r.text())).matchAll(/<meta (\w+?)="(.*?)" (\w+?)="(.*?)">/).map(m=>[m[m.indexOf("itemprop")+1], m[m.indexOf("content")+1]]))
+			const metadata = Object.fromEntries((await fetch(url).then(r=>r.text())).matchAll(/<meta (\w+?)="(.*?)" (\w+?)="(.*?)">/g).map(m=>[m[m.indexOf("itemprop")+1], m[m.indexOf("content")+1]]))
 
 			const dateStr = metadata["datePublished"]
 			s["_desc"] = metadata["name"]

--- a/js/providers/youtube.js
+++ b/js/providers/youtube.js
@@ -7,7 +7,12 @@ export class Youtube extends Provider(OAuth2PKCEAuth){
 	Payload(auth){
 		return {headers:{"authorization":`${auth["token_type"] ?? "Bearer"} ${auth["access_token"]}`}}
 	}
-
+	async Authenticate(manuallyTriggered=false, request={}){
+		request["access_type"] = "offline"
+		if(manuallyTriggered)
+			request["prompt"] = "select_account" // TODO: change to "login_hint" once I can get that info!
+		return super.Authenticate(manuallyTriggered, request)
+	}
 	async GetUIDAndName(auth){
 		console.log(auth)
 		var userData = (await WebRequest.GET("https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true&fields=items(id,snippet/title)", this.Payload(auth)))["items"][0]

--- a/services.json
+++ b/services.json
@@ -19,6 +19,9 @@
 		"PKCE": false
 	},
 	"youtube":{
-		"Site": "https://youtube.com"
+		"Site": "https://youtube.com",
+		"ClientID": "463633408812-06gm6hp78drr5djcdee1j5s0r7t5j0bp.apps.googleusercontent.com",
+		"AuthenticationAPI": "https://accounts.google.com/o/oauth2/v2/auth",
+		"Scopes": ["https://www.googleapis.com/auth/youtube.readonly"]
 	}
 }

--- a/services.json
+++ b/services.json
@@ -22,6 +22,7 @@
 		"Site": "https://youtube.com",
 		"ClientID": "463633408812-06gm6hp78drr5djcdee1j5s0r7t5j0bp.apps.googleusercontent.com",
 		"AuthenticationAPI": "https://accounts.google.com/o/oauth2/v2/auth",
+		"TokenAPI": "https://oauth2.googleapis.com/token",
 		"Scopes": ["https://www.googleapis.com/auth/youtube.readonly"]
 	}
 }


### PR DESCRIPTION
currently only pulls the first 50 connections, will need to paginate to pull more. 
youtube API required client_secret for refresh_tokens, even though the oauth spec doesn't?

the intent of this is to leverage youtube's API to consistently fetch livestream data - as the current web-scraping method could be rendered obsolete at any moment, and doesn't provide any account verification